### PR TITLE
pokemon-simulator.jsの修正

### DIFF
--- a/src/models/pokemon-simulator.js
+++ b/src/models/pokemon-simulator.js
@@ -404,7 +404,7 @@ class PokemonSimulator {
             helpCount *= pokemon.skillEffectRate;
 
             for(let subPokemon of pokemonList) {
-              pokemon.berryEnergyPerDay += subPokemon.berryEnergyPerHelp * helpCount * subPokemon.fixedFoodRate;
+              pokemon.berryEnergyPerDay += subPokemon.berryEnergyPerHelp * helpCount * (1 - subPokemon.fixedFoodRate);
               for(let foodName in subPokemon.foodPerHelp) {
                 pokemon[foodName] = (pokemon[foodName] ?? 0) + subPokemon.foodPerHelp[foodName] * helpCount * subPokemon.fixedFoodRate;
               }


### PR DESCRIPTION
おてつだいサポートSおよびおてつだいブーストの計算式において、きのみの入手確率が食材確率になっていた部分を修正。